### PR TITLE
Remove dependency on ruby-git

### DIFF
--- a/tempest_time.gemspec
+++ b/tempest_time.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'git', '~>1.5'
   spec.add_dependency 'httparty', '~>0.16'
   spec.add_dependency 'pastel', '~> 0.7.2'
-  spec.add_dependency 'ruby-git', '~>0.2'
   spec.add_dependency 'thor', '~> 0.20.0'
   spec.add_dependency 'tty-command', '~> 0.8.0'
   spec.add_dependency 'tty-config', '~> 0.3.0'


### PR DESCRIPTION
The ruby-git gem was yanked from rubygems.org.  It looks like this project isn't using it so this PR simply removes the dependency.

This project does use the `git` gem.